### PR TITLE
get_jwt_uri() makes a Grant URI with "+" (i.e. %2B) delimited permiss…

### DIFF
--- a/docusign_esign/api_client.py
+++ b/docusign_esign/api_client.py
@@ -100,7 +100,7 @@ class ApiClient(object):
         self.default_headers[header_name] = header_value
 
     def get_jwt_uri(self, client_id, redirect_uri, oauth_base_path):
-        return "https://" + oauth_base_path + "/oauth/auth" + "?" + "response_type=code&" + "client_id=" + quote(client_id, safe="") + "&" + "scope=" + quote("signature+impersonation", safe="") + "&" + "redirect_uri=" + quote(redirect_uri, safe="")
+        return "https://" + oauth_base_path + "/oauth/auth" + "?" + "response_type=code&" + "client_id=" + quote(client_id, safe="") + "&" + "scope=" + quote("signature impersonation", safe="") + "&" + "redirect_uri=" + quote(redirect_uri, safe="")
 
     def configure_jwt_authorization_flow(self, private_key_filename, oauth_base_path, client_id, user_id, expires_in):
         now = math.floor(time())


### PR DESCRIPTION
…ions for scope instead of "space" (i.e. %20) delimited, leading to a partial grant URI

e.g.:

 wrong: https://account-d.docusign.com/oauth/auth?response_type=code&client_id=277345e3-4597-474e-83ab-7ab6c89d1899&scope=signature%2Bimpersonation&redirect_uri=https%3A%2F%2Fwww.docusign.com%2Fapi
 right: https://account-d.docusign.com/oauth/auth?response_type=code&client_id=277345e3-4597-474e-83ab-7ab6c89d1899&scope=signature%20impersonation&redirect_uri=https%3A%2F%2Fwww.docusign.com%2Fapi