### PR TITLE
Anchor our PyJWT requirement to pre-2.0 to avoid breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ six >= 1.8.0
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15
-PyJWT>=1.7.1
+PyJWT>=1.7.1,<2
 cryptography>=2.5
 nose>=1.3.7

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ VERSION = "3.7.1"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT>=1.7.1", "cryptography>=2.5", "nose>=1.3.7"]
+REQUIRES = ["urllib3 >= 1.15", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT>=1.7.1,<2", "cryptography>=2.5", "nose>=1.3.7"]
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""


### PR DESCRIPTION
Solves #94 by locking PyJWT below 2.0 for now.