### PR TITLE
Version 3.9.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 branches:
   only: 
     - master
-    - v2-master
 language: python
 python:
   - "2.7"
@@ -13,7 +12,3 @@ install:
     - pip install -r test-requirements.txt
 # command to run tests
 script: nosetests -s
-matrix:
-  allow_failures:
-    - python: nightly # Allow all tests to fail for nightly
-    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only: 
     - master
+    - v2-master
 language: python
 python:
   - "2.7"
@@ -12,3 +13,7 @@ install:
     - pip install -r test-requirements.txt
 # command to run tests
 script: nosetests -s
+matrix:
+  allow_failures:
+    - python: nightly # Allow all tests to fail for nightly
+    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [3.9.0] - eSignature API v2.1-21.1.01.03 - 2021-04-22
+### Added
+- Added support for version v2.1-21.1.01.03 of the DocuSign eSignature API.
+### Updated
+- Updated the SDK release version.
+- Updated `user_agent` in configurations. Eg; `'Swagger-Codegen/v2.1/3.9.0rc1/python3'`
+- Updated test cases to remove printing sensitive info
+
 ## [3.8.1] - eSignature API v2.1-20.4.01 - 2021-02-26
 ### Changed
 - Added support for version v2.1-20.4.01 of the DocuSign eSignature API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for
 
 ## [3.9.0] - eSignature API v2.1-21.1.01.03 - 2021-04-22
 ### Added
-- Added support for version v2.1-21.1.01.03 of the DocuSign eSignature API.
+- Added new methods `deleteCustomFieldsV2`, `deletePageInfoV2`, `getApplianceEnvelopeInfo`, `getTemplateInfo` to envelopes.
+- Added new method `deleteConnectSecret` to connect.
 ### Updated
+- Added support for version v2.1-21.1.01.03 of the DocuSign eSignature API.
 - Updated the SDK release version.
 - Updated `user_agent` in configurations. Eg; `'Swagger-Codegen/v2.1/3.9.0rc1/python3'`
 - Updated test cases to remove printing sensitive info

--- a/docusign_esign/models/approve.py
+++ b/docusign_esign/models/approve.py
@@ -90,6 +90,7 @@ class Approve(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -178,6 +179,7 @@ class Approve(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -206,7 +208,7 @@ class Approve(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, button_text=None, button_text_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, button_text=None, button_text_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Approve - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -268,6 +270,7 @@ class Approve(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -414,6 +417,8 @@ class Approve(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1761,6 +1766,29 @@ class Approve(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Approve.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Approve.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Approve.
+
+          # noqa: E501
+
+        :param source: The source of this Approve.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/checkbox.py
+++ b/docusign_esign/models/checkbox.py
@@ -99,6 +99,7 @@ class Checkbox(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -196,6 +197,7 @@ class Checkbox(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -224,7 +226,7 @@ class Checkbox(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, selected=None, selected_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, selected=None, selected_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Checkbox - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -295,6 +297,7 @@ class Checkbox(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -459,6 +462,8 @@ class Checkbox(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2005,6 +2010,29 @@ class Checkbox(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Checkbox.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Checkbox.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Checkbox.
+
+          # noqa: E501
+
+        :param source: The source of this Checkbox.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/comment_thread.py
+++ b/docusign_esign/models/comment_thread.py
@@ -89,6 +89,7 @@ class CommentThread(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -177,6 +178,7 @@ class CommentThread(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -206,7 +208,7 @@ class CommentThread(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, comments=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, thread_id=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, comments=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, thread_id=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """CommentThread - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -267,6 +269,7 @@ class CommentThread(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -412,6 +415,8 @@ class CommentThread(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1740,6 +1745,29 @@ class CommentThread(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this CommentThread.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this CommentThread.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this CommentThread.
+
+          # noqa: E501
+
+        :param source: The source of this CommentThread.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/commission_county.py
+++ b/docusign_esign/models/commission_county.py
@@ -102,6 +102,7 @@ class CommissionCounty(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class CommissionCounty(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class CommissionCounty(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """CommissionCounty - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class CommissionCounty(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class CommissionCounty(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class CommissionCounty(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this CommissionCounty.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this CommissionCounty.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this CommissionCounty.
+
+          # noqa: E501
+
+        :param source: The source of this CommissionCounty.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/commission_expiration.py
+++ b/docusign_esign/models/commission_expiration.py
@@ -102,6 +102,7 @@ class CommissionExpiration(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class CommissionExpiration(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class CommissionExpiration(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """CommissionExpiration - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class CommissionExpiration(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class CommissionExpiration(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class CommissionExpiration(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this CommissionExpiration.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this CommissionExpiration.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this CommissionExpiration.
+
+          # noqa: E501
+
+        :param source: The source of this CommissionExpiration.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/commission_number.py
+++ b/docusign_esign/models/commission_number.py
@@ -102,6 +102,7 @@ class CommissionNumber(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class CommissionNumber(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class CommissionNumber(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """CommissionNumber - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class CommissionNumber(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class CommissionNumber(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class CommissionNumber(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this CommissionNumber.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this CommissionNumber.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this CommissionNumber.
+
+          # noqa: E501
+
+        :param source: The source of this CommissionNumber.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/commission_state.py
+++ b/docusign_esign/models/commission_state.py
@@ -102,6 +102,7 @@ class CommissionState(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class CommissionState(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class CommissionState(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """CommissionState - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class CommissionState(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class CommissionState(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class CommissionState(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this CommissionState.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this CommissionState.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this CommissionState.
+
+          # noqa: E501
+
+        :param source: The source of this CommissionState.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/company.py
+++ b/docusign_esign/models/company.py
@@ -102,6 +102,7 @@ class Company(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class Company(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class Company(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Company - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class Company(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class Company(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class Company(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Company.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Company.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Company.
+
+          # noqa: E501
+
+        :param source: The source of this Company.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/currency.py
+++ b/docusign_esign/models/currency.py
@@ -111,6 +111,7 @@ class Currency(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -222,6 +223,7 @@ class Currency(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -252,7 +254,7 @@ class Currency(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, numerical_value=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, numerical_value=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Currency - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -335,6 +337,7 @@ class Currency(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -525,6 +528,8 @@ class Currency(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2339,6 +2344,29 @@ class Currency(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Currency.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Currency.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Currency.
+
+          # noqa: E501
+
+        :param source: The source of this Currency.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/date_signed.py
+++ b/docusign_esign/models/date_signed.py
@@ -90,6 +90,7 @@ class DateSigned(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -180,6 +181,7 @@ class DateSigned(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -210,7 +212,7 @@ class DateSigned(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """DateSigned - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -272,6 +274,7 @@ class DateSigned(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -420,6 +423,8 @@ class DateSigned(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1771,6 +1776,29 @@ class DateSigned(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this DateSigned.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this DateSigned.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this DateSigned.
+
+          # noqa: E501
+
+        :param source: The source of this DateSigned.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/decline.py
+++ b/docusign_esign/models/decline.py
@@ -92,6 +92,7 @@ class Decline(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -182,6 +183,7 @@ class Decline(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -210,7 +212,7 @@ class Decline(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, button_text=None, button_text_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, decline_reason=None, decline_reason_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, button_text=None, button_text_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, decline_reason=None, decline_reason_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Decline - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -274,6 +276,7 @@ class Decline(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -424,6 +427,8 @@ class Decline(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1815,6 +1820,29 @@ class Decline(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Decline.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Decline.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Decline.
+
+          # noqa: E501
+
+        :param source: The source of this Decline.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/draw.py
+++ b/docusign_esign/models/draw.py
@@ -84,6 +84,7 @@ class Draw(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -164,6 +165,7 @@ class Draw(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -190,7 +192,7 @@ class Draw(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, allow_signer_upload=None, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, use_background_as_canvas=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, allow_signer_upload=None, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, use_background_as_canvas=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Draw - a model defined in Swagger"""  # noqa: E501
 
         self._allow_signer_upload = None
@@ -246,6 +248,7 @@ class Draw(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -378,6 +381,8 @@ class Draw(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1591,6 +1596,29 @@ class Draw(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Draw.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Draw.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Draw.
+
+          # noqa: E501
+
+        :param source: The source of this Draw.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/email.py
+++ b/docusign_esign/models/email.py
@@ -110,6 +110,7 @@ class Email(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -224,6 +225,7 @@ class Email(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -258,7 +260,7 @@ class Email(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Email - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -340,6 +342,7 @@ class Email(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -532,6 +535,8 @@ class Email(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2331,6 +2336,29 @@ class Email(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Email.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Email.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Email.
+
+          # noqa: E501
+
+        :param source: The source of this Email.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/email_address.py
+++ b/docusign_esign/models/email_address.py
@@ -90,6 +90,7 @@ class EmailAddress(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -180,6 +181,7 @@ class EmailAddress(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -210,7 +212,7 @@ class EmailAddress(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """EmailAddress - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -272,6 +274,7 @@ class EmailAddress(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -420,6 +423,8 @@ class EmailAddress(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1771,6 +1776,29 @@ class EmailAddress(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this EmailAddress.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this EmailAddress.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this EmailAddress.
+
+          # noqa: E501
+
+        :param source: The source of this EmailAddress.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/envelope_id.py
+++ b/docusign_esign/models/envelope_id.py
@@ -90,6 +90,7 @@ class EnvelopeId(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -178,6 +179,7 @@ class EnvelopeId(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -206,7 +208,7 @@ class EnvelopeId(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """EnvelopeId - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -268,6 +270,7 @@ class EnvelopeId(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -414,6 +417,8 @@ class EnvelopeId(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1761,6 +1766,29 @@ class EnvelopeId(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this EnvelopeId.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this EnvelopeId.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this EnvelopeId.
+
+          # noqa: E501
+
+        :param source: The source of this EnvelopeId.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/first_name.py
+++ b/docusign_esign/models/first_name.py
@@ -90,6 +90,7 @@ class FirstName(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -180,6 +181,7 @@ class FirstName(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -210,7 +212,7 @@ class FirstName(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """FirstName - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -272,6 +274,7 @@ class FirstName(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -420,6 +423,8 @@ class FirstName(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1771,6 +1776,29 @@ class FirstName(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this FirstName.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this FirstName.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this FirstName.
+
+          # noqa: E501
+
+        :param source: The source of this FirstName.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/formula_tab.py
+++ b/docusign_esign/models/formula_tab.py
@@ -119,6 +119,7 @@ class FormulaTab(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -242,6 +243,7 @@ class FormulaTab(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -276,7 +278,7 @@ class FormulaTab(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, formula=None, formula_metadata=None, height=None, height_metadata=None, hidden=None, hidden_metadata=None, is_payment_amount=None, is_payment_amount_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, payment_details=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, round_decimal_places=None, round_decimal_places_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, formula=None, formula_metadata=None, height=None, height_metadata=None, hidden=None, hidden_metadata=None, is_payment_amount=None, is_payment_amount_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, payment_details=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, round_decimal_places=None, round_decimal_places_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """FormulaTab - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -367,6 +369,7 @@ class FormulaTab(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -577,6 +580,8 @@ class FormulaTab(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2573,6 +2578,29 @@ class FormulaTab(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this FormulaTab.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this FormulaTab.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this FormulaTab.
+
+          # noqa: E501
+
+        :param source: The source of this FormulaTab.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/full_name.py
+++ b/docusign_esign/models/full_name.py
@@ -90,6 +90,7 @@ class FullName(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -180,6 +181,7 @@ class FullName(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -210,7 +212,7 @@ class FullName(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """FullName - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -272,6 +274,7 @@ class FullName(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -420,6 +423,8 @@ class FullName(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1771,6 +1776,29 @@ class FullName(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this FullName.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this FullName.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this FullName.
+
+          # noqa: E501
+
+        :param source: The source of this FullName.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/initial_here.py
+++ b/docusign_esign/models/initial_here.py
@@ -83,6 +83,7 @@ class InitialHere(object):
         'scale_value': 'str',
         'scale_value_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -162,6 +163,7 @@ class InitialHere(object):
         'scale_value': 'scaleValue',
         'scale_value_metadata': 'scaleValueMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -188,7 +190,7 @@ class InitialHere(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, optional=None, optional_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, optional=None, optional_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """InitialHere - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -243,6 +245,7 @@ class InitialHere(object):
         self._scale_value = None
         self._scale_value_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -373,6 +376,8 @@ class InitialHere(object):
             self.scale_value_metadata = scale_value_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1563,6 +1568,29 @@ class InitialHere(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this InitialHere.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this InitialHere.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this InitialHere.
+
+          # noqa: E501
+
+        :param source: The source of this InitialHere.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/last_name.py
+++ b/docusign_esign/models/last_name.py
@@ -90,6 +90,7 @@ class LastName(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -180,6 +181,7 @@ class LastName(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -210,7 +212,7 @@ class LastName(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """LastName - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -272,6 +274,7 @@ class LastName(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -420,6 +423,8 @@ class LastName(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1771,6 +1776,29 @@ class LastName(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this LastName.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this LastName.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this LastName.
+
+          # noqa: E501
+
+        :param source: The source of this LastName.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/list.py
+++ b/docusign_esign/models/list.py
@@ -103,6 +103,7 @@ class List(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -206,6 +207,7 @@ class List(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -236,7 +238,7 @@ class List(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, list_items=None, list_selected_value=None, list_selected_value_metadata=None, locale_policy=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, list_items=None, list_selected_value=None, list_selected_value_metadata=None, locale_policy=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """List - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -311,6 +313,7 @@ class List(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -485,6 +488,8 @@ class List(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2123,6 +2128,29 @@ class List(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this List.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this List.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this List.
+
+          # noqa: E501
+
+        :param source: The source of this List.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/model_date.py
+++ b/docusign_esign/models/model_date.py
@@ -110,6 +110,7 @@ class ModelDate(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -224,6 +225,7 @@ class ModelDate(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -258,7 +260,7 @@ class ModelDate(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """ModelDate - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -340,6 +342,7 @@ class ModelDate(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -532,6 +535,8 @@ class ModelDate(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2331,6 +2336,29 @@ class ModelDate(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this ModelDate.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this ModelDate.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this ModelDate.
+
+          # noqa: E501
+
+        :param source: The source of this ModelDate.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/notarize.py
+++ b/docusign_esign/models/notarize.py
@@ -81,6 +81,7 @@ class Notarize(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -156,6 +157,7 @@ class Notarize(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -180,7 +182,7 @@ class Notarize(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Notarize - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -233,6 +235,7 @@ class Notarize(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -357,6 +360,8 @@ class Notarize(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1499,6 +1504,29 @@ class Notarize(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Notarize.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Notarize.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Notarize.
+
+          # noqa: E501
+
+        :param source: The source of this Notarize.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/notary_seal.py
+++ b/docusign_esign/models/notary_seal.py
@@ -81,6 +81,7 @@ class NotarySeal(object):
         'scale_value': 'str',
         'scale_value_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -158,6 +159,7 @@ class NotarySeal(object):
         'scale_value': 'scaleValue',
         'scale_value_metadata': 'scaleValueMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -184,7 +186,7 @@ class NotarySeal(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """NotarySeal - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -237,6 +239,7 @@ class NotarySeal(object):
         self._scale_value = None
         self._scale_value_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -363,6 +366,8 @@ class NotarySeal(object):
             self.scale_value_metadata = scale_value_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1509,6 +1514,29 @@ class NotarySeal(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this NotarySeal.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this NotarySeal.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this NotarySeal.
+
+          # noqa: E501
+
+        :param source: The source of this NotarySeal.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/note.py
+++ b/docusign_esign/models/note.py
@@ -92,6 +92,7 @@ class Note(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -184,6 +185,7 @@ class Note(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -214,7 +216,7 @@ class Note(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Note - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -278,6 +280,7 @@ class Note(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -430,6 +433,8 @@ class Note(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1825,6 +1830,29 @@ class Note(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Note.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Note.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Note.
+
+          # noqa: E501
+
+        :param source: The source of this Note.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/number.py
+++ b/docusign_esign/models/number.py
@@ -114,6 +114,7 @@ class Number(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -232,6 +233,7 @@ class Number(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -266,7 +268,7 @@ class Number(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, formula=None, formula_metadata=None, height=None, height_metadata=None, is_payment_amount=None, is_payment_amount_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, formula=None, formula_metadata=None, height=None, height_metadata=None, is_payment_amount=None, is_payment_amount_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Number - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -352,6 +354,7 @@ class Number(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -552,6 +555,8 @@ class Number(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2439,6 +2444,29 @@ class Number(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Number.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Number.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Number.
+
+          # noqa: E501
+
+        :param source: The source of this Number.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/phone_number.py
+++ b/docusign_esign/models/phone_number.py
@@ -102,6 +102,7 @@ class PhoneNumber(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class PhoneNumber(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class PhoneNumber(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """PhoneNumber - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class PhoneNumber(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class PhoneNumber(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class PhoneNumber(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this PhoneNumber.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this PhoneNumber.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this PhoneNumber.
+
+          # noqa: E501
+
+        :param source: The source of this PhoneNumber.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/poly_line_overlay.py
+++ b/docusign_esign/models/poly_line_overlay.py
@@ -85,6 +85,7 @@ class PolyLineOverlay(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -165,6 +166,7 @@ class PolyLineOverlay(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -190,7 +192,7 @@ class PolyLineOverlay(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, graphics_context=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, overlay_type=None, overlay_type_metadata=None, page_number=None, page_number_metadata=None, poly_lines=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, graphics_context=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, overlay_type=None, overlay_type_metadata=None, page_number=None, page_number_metadata=None, poly_lines=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """PolyLineOverlay - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -247,6 +249,7 @@ class PolyLineOverlay(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -380,6 +383,8 @@ class PolyLineOverlay(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1612,6 +1617,29 @@ class PolyLineOverlay(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this PolyLineOverlay.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this PolyLineOverlay.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this PolyLineOverlay.
+
+          # noqa: E501
+
+        :param source: The source of this PolyLineOverlay.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/sign_here.py
+++ b/docusign_esign/models/sign_here.py
@@ -84,6 +84,7 @@ class SignHere(object):
         'scale_value': 'str',
         'scale_value_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'stamp': 'Stamp',
         'stamp_type': 'str',
         'stamp_type_metadata': 'PropertyMetadata',
@@ -167,6 +168,7 @@ class SignHere(object):
         'scale_value': 'scaleValue',
         'scale_value_metadata': 'scaleValueMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'stamp': 'stamp',
         'stamp_type': 'stampType',
         'stamp_type_metadata': 'stampTypeMetadata',
@@ -196,7 +198,7 @@ class SignHere(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, is_seal_sign_tab=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, optional=None, optional_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, stamp=None, stamp_type=None, stamp_type_metadata=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, is_seal_sign_tab=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, optional=None, optional_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, source=None, stamp=None, stamp_type=None, stamp_type_metadata=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """SignHere - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -252,6 +254,7 @@ class SignHere(object):
         self._scale_value = None
         self._scale_value_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._stamp = None
         self._stamp_type = None
         self._stamp_type_metadata = None
@@ -387,6 +390,8 @@ class SignHere(object):
             self.scale_value_metadata = scale_value_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if stamp is not None:
             self.stamp = stamp
         if stamp_type is not None:
@@ -1606,6 +1611,29 @@ class SignHere(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this SignHere.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this SignHere.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this SignHere.
+
+          # noqa: E501
+
+        :param source: The source of this SignHere.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def stamp(self):

--- a/docusign_esign/models/signer_attachment.py
+++ b/docusign_esign/models/signer_attachment.py
@@ -83,6 +83,7 @@ class SignerAttachment(object):
         'scale_value': 'str',
         'scale_value_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -162,6 +163,7 @@ class SignerAttachment(object):
         'scale_value': 'scaleValue',
         'scale_value_metadata': 'scaleValueMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -188,7 +190,7 @@ class SignerAttachment(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, optional=None, optional_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, optional=None, optional_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, scale_value=None, scale_value_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """SignerAttachment - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -243,6 +245,7 @@ class SignerAttachment(object):
         self._scale_value = None
         self._scale_value_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -373,6 +376,8 @@ class SignerAttachment(object):
             self.scale_value_metadata = scale_value_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1563,6 +1568,29 @@ class SignerAttachment(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this SignerAttachment.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this SignerAttachment.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this SignerAttachment.
+
+          # noqa: E501
+
+        :param source: The source of this SignerAttachment.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/smart_section.py
+++ b/docusign_esign/models/smart_section.py
@@ -89,6 +89,7 @@ class SmartSection(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'start_anchor': 'str',
         'start_position': 'SmartSectionAnchorPosition',
         'status': 'str',
@@ -175,6 +176,7 @@ class SmartSection(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'start_anchor': 'startAnchor',
         'start_position': 'startPosition',
         'status': 'status',
@@ -202,7 +204,7 @@ class SmartSection(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, case_sensitive=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, display_settings=None, document_id=None, document_id_metadata=None, end_anchor=None, end_position=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, overlay_type=None, overlay_type_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, remove_end_anchor=None, remove_start_anchor=None, shared=None, shared_metadata=None, smart_contract_information=None, start_anchor=None, start_position=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, case_sensitive=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, display_settings=None, document_id=None, document_id_metadata=None, end_anchor=None, end_position=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, locked=None, locked_metadata=None, merge_field=None, merge_field_xml=None, overlay_type=None, overlay_type_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, remove_end_anchor=None, remove_start_anchor=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, start_anchor=None, start_position=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """SmartSection - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -263,6 +265,7 @@ class SmartSection(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._start_anchor = None
         self._start_position = None
         self._status = None
@@ -406,6 +409,8 @@ class SmartSection(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if start_anchor is not None:
             self.start_anchor = start_anchor
         if start_position is not None:
@@ -1732,6 +1737,29 @@ class SmartSection(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this SmartSection.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this SmartSection.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this SmartSection.
+
+          # noqa: E501
+
+        :param source: The source of this SmartSection.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def start_anchor(self):

--- a/docusign_esign/models/ssn.py
+++ b/docusign_esign/models/ssn.py
@@ -110,6 +110,7 @@ class Ssn(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -224,6 +225,7 @@ class Ssn(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -258,7 +260,7 @@ class Ssn(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Ssn - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -340,6 +342,7 @@ class Ssn(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -532,6 +535,8 @@ class Ssn(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2331,6 +2336,29 @@ class Ssn(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Ssn.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Ssn.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Ssn.
+
+          # noqa: E501
+
+        :param source: The source of this Ssn.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/tab_group.py
+++ b/docusign_esign/models/tab_group.py
@@ -85,6 +85,7 @@ class TabGroup(object):
         'recipient_id_guid_metadata': 'PropertyMetadata',
         'recipient_id_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -168,6 +169,7 @@ class TabGroup(object):
         'recipient_id_guid_metadata': 'recipientIdGuidMetadata',
         'recipient_id_metadata': 'recipientIdMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -196,7 +198,7 @@ class TabGroup(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, group_label=None, group_label_metadata=None, group_rule=None, group_rule_metadata=None, height=None, height_metadata=None, maximum_allowed=None, maximum_allowed_metadata=None, merge_field=None, merge_field_xml=None, minimum_required=None, minimum_required_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_order=None, tab_order_metadata=None, tab_scope=None, tab_scope_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, validation_message=None, validation_message_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, group_label=None, group_label_metadata=None, group_rule=None, group_rule_metadata=None, height=None, height_metadata=None, maximum_allowed=None, maximum_allowed_metadata=None, merge_field=None, merge_field_xml=None, minimum_required=None, minimum_required_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_order=None, tab_order_metadata=None, tab_scope=None, tab_scope_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, validation_message=None, validation_message_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """TabGroup - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -253,6 +255,7 @@ class TabGroup(object):
         self._recipient_id_guid_metadata = None
         self._recipient_id_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -389,6 +392,8 @@ class TabGroup(object):
             self.recipient_id_metadata = recipient_id_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1627,6 +1632,29 @@ class TabGroup(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this TabGroup.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this TabGroup.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this TabGroup.
+
+          # noqa: E501
+
+        :param source: The source of this TabGroup.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/text.py
+++ b/docusign_esign/models/text.py
@@ -114,6 +114,7 @@ class Text(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -232,6 +233,7 @@ class Text(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -266,7 +268,7 @@ class Text(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, formula=None, formula_metadata=None, height=None, height_metadata=None, is_payment_amount=None, is_payment_amount_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, formula=None, formula_metadata=None, height=None, height_metadata=None, is_payment_amount=None, is_payment_amount_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Text - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -352,6 +354,7 @@ class Text(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -552,6 +555,8 @@ class Text(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2439,6 +2444,29 @@ class Text(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Text.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Text.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Text.
+
+          # noqa: E501
+
+        :param source: The source of this Text.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/title.py
+++ b/docusign_esign/models/title.py
@@ -102,6 +102,7 @@ class Title(object):
         'required': 'str',
         'required_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -204,6 +205,7 @@ class Title(object):
         'required': 'required',
         'required_metadata': 'requiredMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -234,7 +236,7 @@ class Title(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Title - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -308,6 +310,7 @@ class Title(object):
         self._required = None
         self._required_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -480,6 +483,8 @@ class Title(object):
             self.required_metadata = required_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2095,6 +2100,29 @@ class Title(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Title.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Title.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Title.
+
+          # noqa: E501
+
+        :param source: The source of this Title.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/view.py
+++ b/docusign_esign/models/view.py
@@ -93,6 +93,7 @@ class View(object):
         'required_metadata': 'PropertyMetadata',
         'required_read': 'str',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -184,6 +185,7 @@ class View(object):
         'required_metadata': 'requiredMetadata',
         'required_read': 'requiredRead',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -212,7 +214,7 @@ class View(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, button_text=None, button_text_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, required_read=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, button_text=None, button_text_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, merge_field=None, merge_field_xml=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, required=None, required_metadata=None, required_read=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """View - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -277,6 +279,7 @@ class View(object):
         self._required_metadata = None
         self._required_read = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -429,6 +432,8 @@ class View(object):
             self.required_read = required_read
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -1843,6 +1848,29 @@ class View(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this View.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this View.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this View.
+
+          # noqa: E501
+
+        :param source: The source of this View.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/docusign_esign/models/zip.py
+++ b/docusign_esign/models/zip.py
@@ -110,6 +110,7 @@ class Zip(object):
         'shared': 'str',
         'shared_metadata': 'PropertyMetadata',
         'smart_contract_information': 'SmartContractInformation',
+        'source': 'str',
         'status': 'str',
         'status_metadata': 'PropertyMetadata',
         'tab_group_labels': 'list[str]',
@@ -226,6 +227,7 @@ class Zip(object):
         'shared': 'shared',
         'shared_metadata': 'sharedMetadata',
         'smart_contract_information': 'smartContractInformation',
+        'source': 'source',
         'status': 'status',
         'status_metadata': 'statusMetadata',
         'tab_group_labels': 'tabGroupLabels',
@@ -262,7 +264,7 @@ class Zip(object):
         'y_position_metadata': 'yPositionMetadata'
     }
 
-    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, use_dash4=None, use_dash4_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
+    def __init__(self, anchor_allow_white_space_in_characters=None, anchor_allow_white_space_in_characters_metadata=None, anchor_case_sensitive=None, anchor_case_sensitive_metadata=None, anchor_horizontal_alignment=None, anchor_horizontal_alignment_metadata=None, anchor_ignore_if_not_present=None, anchor_ignore_if_not_present_metadata=None, anchor_match_whole_word=None, anchor_match_whole_word_metadata=None, anchor_string=None, anchor_string_metadata=None, anchor_tab_processor_version=None, anchor_tab_processor_version_metadata=None, anchor_units=None, anchor_units_metadata=None, anchor_x_offset=None, anchor_x_offset_metadata=None, anchor_y_offset=None, anchor_y_offset_metadata=None, bold=None, bold_metadata=None, conceal_value_on_document=None, conceal_value_on_document_metadata=None, conditional_parent_label=None, conditional_parent_label_metadata=None, conditional_parent_value=None, conditional_parent_value_metadata=None, custom_tab_id=None, custom_tab_id_metadata=None, disable_auto_size=None, disable_auto_size_metadata=None, document_id=None, document_id_metadata=None, error_details=None, font=None, font_color=None, font_color_metadata=None, font_metadata=None, font_size=None, font_size_metadata=None, form_order=None, form_order_metadata=None, form_page_label=None, form_page_label_metadata=None, form_page_number=None, form_page_number_metadata=None, height=None, height_metadata=None, italic=None, italic_metadata=None, locale_policy=None, locked=None, locked_metadata=None, max_length=None, max_length_metadata=None, merge_field=None, merge_field_xml=None, name=None, name_metadata=None, original_value=None, original_value_metadata=None, page_number=None, page_number_metadata=None, recipient_id=None, recipient_id_guid=None, recipient_id_guid_metadata=None, recipient_id_metadata=None, require_all=None, require_all_metadata=None, required=None, required_metadata=None, require_initial_on_shared_change=None, require_initial_on_shared_change_metadata=None, sender_required=None, sender_required_metadata=None, shared=None, shared_metadata=None, smart_contract_information=None, source=None, status=None, status_metadata=None, tab_group_labels=None, tab_group_labels_metadata=None, tab_id=None, tab_id_metadata=None, tab_label=None, tab_label_metadata=None, tab_order=None, tab_order_metadata=None, tab_type=None, tab_type_metadata=None, template_locked=None, template_locked_metadata=None, template_required=None, template_required_metadata=None, tooltip=None, tool_tip_metadata=None, underline=None, underline_metadata=None, use_dash4=None, use_dash4_metadata=None, validation_message=None, validation_message_metadata=None, validation_pattern=None, validation_pattern_metadata=None, value=None, value_metadata=None, width=None, width_metadata=None, x_position=None, x_position_metadata=None, y_position=None, y_position_metadata=None):  # noqa: E501
         """Zip - a model defined in Swagger"""  # noqa: E501
 
         self._anchor_allow_white_space_in_characters = None
@@ -344,6 +346,7 @@ class Zip(object):
         self._shared = None
         self._shared_metadata = None
         self._smart_contract_information = None
+        self._source = None
         self._status = None
         self._status_metadata = None
         self._tab_group_labels = None
@@ -538,6 +541,8 @@ class Zip(object):
             self.shared_metadata = shared_metadata
         if smart_contract_information is not None:
             self.smart_contract_information = smart_contract_information
+        if source is not None:
+            self.source = source
         if status is not None:
             self.status = status
         if status_metadata is not None:
@@ -2341,6 +2346,29 @@ class Zip(object):
         """
 
         self._smart_contract_information = smart_contract_information
+
+    @property
+    def source(self):
+        """Gets the source of this Zip.  # noqa: E501
+
+          # noqa: E501
+
+        :return: The source of this Zip.  # noqa: E501
+        :rtype: str
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source):
+        """Sets the source of this Zip.
+
+          # noqa: E501
+
+        :param source: The source of this Zip.  # noqa: E501
+        :type: str
+        """
+
+        self._source = source
 
     @property
     def status(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages, Command, os  # noqa: H301
 
 NAME = "docusign-esign"
-VERSION = "3.9.0rc1"
+VERSION = "3.9.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
## [3.9.0] - eSignature API v2.1-21.1.01.03 - 2021-04-22
### Added
- Added new methods `deleteCustomFieldsV2`, `deletePageInfoV2`, `getApplianceEnvelopeInfo`, `getTemplateInfo` to envelopes.
- Added new method `deleteConnectSecret` to connect.
### Updated
- Added support for version v2.1-21.1.01.03 of the DocuSign eSignature API.
- Updated the SDK release version.
- Updated `user_agent` in configurations. Eg; `'Swagger-Codegen/v2.1/3.9.0rc1/python3'`
- Updated test cases to remove printing sensitive info
