### PR TITLE
Version 2.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
 ## [2.9.0] - eSignature API v2-21.1.01.03 - 2021-04-22
+### Added
+- Added new method `delete_connect_secret` to connect.
 ### Changed
 - Added support for version v2-21.1.01.03 of the DocuSign eSignature API.
 - Updated the SDK release version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [2.9.0] - eSignature API v2-21.1.01.03 - 2021-04-22
+### Changed
+- Added support for version v2-21.1.01.03 of the DocuSign eSignature API.
+- Updated the SDK release version.
+- Updated `user_agent` in configurations. Eg: `'Swagger-Codegen/v2.1/3.9.0rc1/python3'`.
+- Updated test cases to remove printing sensitive info.
+
 ## [2.8.1] - eSignature API v2-20.4.01 - 2021-02-26
 ### Changed
 - Added support for version v2-20.4.01 of the DocuSign eSignature API.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages, Command, os  # noqa: H301
 
 NAME = "docusign-esign"
-VERSION = "2.9.0rc1"
+VERSION = "2.9.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
### Added
- Added new method `delete_connect_secret` to connect.
### Changed
- Added support for version v2-21.1.01.03 of the DocuSign eSignature API.
- Updated the SDK release version.
- Updated `user_agent` in configurations. Eg: `'Swagger-Codegen/v2.1/3.9.0rc1/python3'`.
- Updated test cases to remove printing sensitive info.
