### PR TITLE
Support urllib3 2.6.0 header API changes

### DIFF
--- a/docusign_esign/client/api_response.py
+++ b/docusign_esign/client/api_response.py
@@ -46,11 +46,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
Adds compatibility for urllib3 2.6.0 by replacing deprecated [getheader() and getheaders()](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) usage.