### PR TITLE
Version 6.0.0rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v6.0.0rc1] - eSignature API v2.1-25.3.01.00 - 2026-01-13
+### Changed
+- Added support for version v2.1-25.3.01.00 of the DocuSign ESignature API.
+- Dropped support for Python 3.8 and lower versions.
+- Updated deprecated urllib3 usage so users can upgrade to urllib3 2.6.0+ (fixes CVE-2025-66471).
+- Updated the SDK release version.
+
 ## [v5.4.0] - eSignature API v2.1-25.3.01.00 - 2025-09-29
 ### Changed
 - Added support for version v2.1-25.3.01.00 of the Docusign ESignature API.

--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: v2.1
-- **Latest SDK version**: 5.4.0
+- **Latest SDK version**: 6.0.0rc1
 
 <a id="requirements"></a>
 ## Requirements
-*   Python 2.7 (3.7+ recommended)
+*   Python 3.9+
 *   Free [developer account](https://go.docusign.com/o/sandbox/?postActivateUrl=https://developers.docusign.com/)
 
 <a id="compatibility"></a>
 ## Compatibility
-*   Python 2.7+
+*   Python 3.9+
 
 <a id="pathSetup"></a>
 ### Path setup:
 1. Locate your Python installation, also referred to as a **site-packages** folder. This folder is usually labeled in a format of **Python{VersionNumber}**.  
     **Examples:**
-    *   Unix/Linux: **/usr/lib/python2.7**
-    *   Mac: **/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7**
-    *   Windows: **C:\Users\{username}\AppData\Local\Programs\Python\Python37**
+    *   Unix/Linux: **/usr/lib/python3.9**
+    *   Mac: **/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9**
+    *   Windows: **C:\Users\{username}\AppData\Local\Programs\Python\Python39**
 2. Add your Python folder’s path to your system as an environment variable.  
     **Unix/Linux:**
     1. Type the following command into your console: \
@@ -85,7 +85,7 @@ This client has the following external dependencies:
 *   six v1.8.0+
 *   python_dateutil v2.5.3+
 *   setuptools v21.0.0+
-*   urllib3 v1.15.1+
+*   urllib3 v2.6.0+
 *   PyJWT v2.0.0+
 *   cryptography v2.5+
 

--- a/docusign_esign/client/api_response.py
+++ b/docusign_esign/client/api_response.py
@@ -46,11 +46,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):

--- a/docusign_esign/client/configuration.py
+++ b/docusign_esign/client/configuration.py
@@ -116,9 +116,9 @@ class Configuration(object):
         python_version = platform.python_version()
 
         if six.PY3:
-            self.user_agent = "Swagger-Codegen/v2.1/5.4.0/python3/" + f"{python_version}"
+            self.user_agent = "Swagger-Codegen/v2.1/6.0.0rc1/python3/" + f"{python_version}"
         else:
-            self.user_agent = "Swagger-Codegen/v2.1/5.4.0/python2/" + f"{python_version}"
+            self.user_agent = "Swagger-Codegen/v2.1/6.0.0rc1/python2/" + f"{python_version}"
 
 
     @classmethod
@@ -274,5 +274,5 @@ class Configuration(object):
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v2.1\n"\
-               "SDK Package Version: 5.4.0".\
+               "SDK Package Version: 6.0.0rc1".\
                format(env=sys.platform, pyversion=sys.version)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages, Command, os  # noqa: H301	
 
 NAME = "docusign-esign"
-VERSION = "5.4.0"
+VERSION = "6.0.0rc1"
 # To install the library, run the following
 #
 # python setup.py install
@@ -22,7 +22,7 @@ VERSION = "5.4.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT>=2.0.0", "cryptography>=2.5"]
+REQUIRES = ["urllib3 >= 2.6.0, < 3.0.0", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT>=2.0.0", "cryptography>=2.5"]
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""


### PR DESCRIPTION
### Changed
- Added support for version v2.1-25.3.01.00 of the DocuSign ESignature API.
- Dropped support for Python 3.8 and lower versions.
- Updated deprecated urllib3 usage so users can upgrade to urllib3 2.6.0+ (fixes CVE-2025-66471).
- Updated the SDK release version.
