### PR TITLE
Support passing arguments to `urllib3` classes

### DIFF
--- a/docusign_esign/client/api_client.py
+++ b/docusign_esign/client/api_client.py
@@ -69,13 +69,13 @@ class ApiClient(object):
 
     OAUTH_TYPES = (OAuthToken.__name__, OAuthUserInfo.__name__, Account.__name__, Organization.__name__, Link.__name__)
 
-    def __init__(self, host=None, header_name=None, header_value=None, cookie=None, oauth_host_name=None, base_path=None):
+    def __init__(self, host=None, header_name=None, header_value=None, cookie=None, oauth_host_name=None, base_path=None, connection_pool_kwargs=None):
         """
         Constructor of the class.
         """
 
         config = Configuration()
-        self.rest_client = RESTClientObject(configuration=config)
+        self.rest_client = RESTClientObject(configuration=config, connection_pool_kwargs=connection_pool_kwargs)
         self.default_headers = {'X-DocuSign-SDK': 'Python'}
         if header_name is not None:
             self.default_headers[header_name] = header_value

--- a/docusign_esign/client/api_response.py
+++ b/docusign_esign/client/api_response.py
@@ -55,7 +55,7 @@ class RESTResponse(io.IOBase):
 
 class RESTClientObject(object):
 
-    def __init__(self, pools_size=4, maxsize=None, configuration=None):
+    def __init__(self, pools_size=4, maxsize=None, configuration=None, connection_pool_kwargs=None):
         # urllib3.PoolManager will pass all kw parameters to connectionpool
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
@@ -81,6 +81,8 @@ class RESTClientObject(object):
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
+        if connection_pool_kwargs is not None:
+            addition_pool_args.update(connection_pool_kwargs)
 
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:


### PR DESCRIPTION
`urllib3`'s `PoolManager` and `ConnectionPool` provide useful settings like `tiemout` and `retries`. This allows users to pass a dictionary of kwargs to `ApiClient`, which will get passed to the `PoolManager`, which will then pass along any extra kwargs to the `ConnectionPool`, allowing for advanced configuration.

My goal is to be able to configure the underlying `ConnectionPool` to be able to handle some recent network issues that we have been having.